### PR TITLE
Add product image create and delete

### DIFF
--- a/app/Events/ProductImageDeleting.php
+++ b/app/Events/ProductImageDeleting.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ProductImage;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductImageDeleting
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public ProductImage $productImage)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Admin\Product\ProductDetachCategoryRequest;
 use App\Http\Requests\Admin\Product\ProductIndexRequest;
 use App\Http\Requests\Admin\Product\ProductStoreRequest;
 use App\Http\Requests\Admin\Product\ProductUpdateRequest;
+use Illuminate\Support\Facades\Storage;
 
 class ProductController extends Controller
 {
@@ -58,6 +59,16 @@ class ProductController extends Controller
             'stock' => $validatedData['stock'] ?? 0,
         ]);
         $product->categories()->attach($validatedData['categories']);
+
+        if (isset($validatedData['images']) && count($validatedData['images']) > 0) {
+            foreach ($validatedData['images'] as $image) {
+                $path = Storage::disk('public')->putFileAs('products', $image, $image->hashName());
+
+                $product->images()->create([
+                    'path' => $path
+                ]);
+            }
+        }
 
         $product->load(['categories', 'images']);
 

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -34,7 +34,7 @@ class ProductController extends Controller
         $queryProcessor->sort($query, $sort_by, $sort_order);
         $queryProcessor->paginate($query, $page, $per_page);
 
-        $products = $query->with(['categories'])->get();
+        $products = $query->with(['categories', 'images'])->get();
 
         return $this->jsend_success([
             'products' => $products,
@@ -59,7 +59,7 @@ class ProductController extends Controller
         ]);
         $product->categories()->attach($validatedData['categories']);
 
-        $product->load(['categories']);
+        $product->load(['categories', 'images']);
 
         return $this->jsend_success([
             'product' => $product
@@ -68,7 +68,7 @@ class ProductController extends Controller
 
     public function show(Product $product)
     {
-        $product->load(['categories']);
+        $product->load(['categories', 'images']);
 
         return $this->jsend_success([
             'product' => $product
@@ -80,7 +80,7 @@ class ProductController extends Controller
         $validatedData = $request->validated();
 
         $product->update($validatedData);
-        $product->load(['categories']);
+        $product->load(['categories', 'images']);
 
         return $this->jsend_success([
             'product' => $product

--- a/app/Http/Controllers/Admin/ProductImageController.php
+++ b/app/Http/Controllers/Admin/ProductImageController.php
@@ -31,8 +31,10 @@ class ProductImageController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(ProductImage $productImage, Product $product)
+    public function destroy(Product $product, ProductImage $productImage)
     {
-        //
+        $productImage->delete();
+
+        return $this->jsend_success(null);
     }
 }

--- a/app/Http/Controllers/Admin/ProductImageController.php
+++ b/app/Http/Controllers/Admin/ProductImageController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use App\Models\ProductImage;
+use App\Traits\JSendResponse;
+use App\Http\Requests\Admin\Product\ProductImageStoreRequest;
+use Illuminate\Support\Facades\Storage;
+
+class ProductImageController extends Controller
+{
+    use JSendResponse;
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(ProductImageStoreRequest $request, Product $product)
+    {
+        $image = $request->file('image');
+
+        $path = Storage::disk('public')->putFileAs('products', $image, $image->hashName());
+        $product->images()->create([
+            'path' => $path,
+        ]);
+
+        return $this->jsend_success(null);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(ProductImage $productImage, Product $product)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Admin/ProductImageController.php
+++ b/app/Http/Controllers/Admin/ProductImageController.php
@@ -18,6 +18,12 @@ class ProductImageController extends Controller
      */
     public function store(ProductImageStoreRequest $request, Product $product)
     {
+        if ($product->images()->count() >= 7) {
+            return $this->jsend_fail([
+                'message' => 'Product images limit reached',
+            ], 400);
+        }
+
         $image = $request->file('image');
 
         $path = Storage::disk('public')->putFileAs('products', $image, $image->hashName());

--- a/app/Http/Requests/Admin/Product/ProductImageStoreRequest.php
+++ b/app/Http/Requests/Admin/Product/ProductImageStoreRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Admin\Product;
+
+use App\Http\Requests\BaseFormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class ProductImageStoreRequest extends BaseFormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'image' => [
+                'required',
+                File::image()
+                    ->max('5mb')
+                    ->dimensions(
+                        Rule::dimensions()
+                            ->minWidth(500)
+                            ->minHeight(500)
+                            ->maxWidth(2000)
+                            ->maxHeight(2000)
+                    ),
+            ]
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Product/ProductStoreRequest.php
+++ b/app/Http/Requests/Admin/Product/ProductStoreRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Admin\Product;
 
 use App\Http\Requests\BaseFormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
 
 class ProductStoreRequest extends BaseFormRequest
 {
@@ -29,6 +31,19 @@ class ProductStoreRequest extends BaseFormRequest
             'stock' => ['nullable', 'integer', 'min:0'],
             'categories' => ['nullable', 'array', 'min:1'],
             'categories.*' => ['integer', 'exists:categories,id'],
+            'images' => ['nullable', 'array', 'min:1', 'max:7'],
+            'images.*' => [
+                'required',
+                File::image()
+                    ->max('5mb')
+                    ->dimensions(
+                        Rule::dimensions()
+                            ->minWidth(500)
+                            ->minHeight(500)
+                            ->maxWidth(2000)
+                            ->maxHeight(2000)
+                    ),
+            ],
         ];
     }
 }

--- a/app/Listeners/DeleteProductImages.php
+++ b/app/Listeners/DeleteProductImages.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ProductImageDeleting;
+use Illuminate\Support\Facades\Storage;
+
+class DeleteProductImages
+{
+    public function handle(ProductImageDeleting $event): void
+    {
+        if (Storage::disk('public')->exists($event->productImage->path)) {
+            Storage::disk('public')->delete($event->productImage->path);
+        }
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Product extends Model
 {
@@ -18,5 +19,10 @@ class Product extends Model
     public function categories(): BelongsToMany
     {
         return $this->belongsToMany(Category::class);
+    }
+
+    public function images(): HasMany
+    {
+        return $this->hasMany(ProductImage::class);
     }
 }

--- a/app/Models/ProductImage.php
+++ b/app/Models/ProductImage.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ProductImage extends Model
+{
+    protected $fillable = [
+        'path'
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/ProductImage.php
+++ b/app/Models/ProductImage.php
@@ -2,12 +2,17 @@
 
 namespace App\Models;
 
+use App\Events\ProductImageDeleting;
 use Illuminate\Database\Eloquent\Model;
 
 class ProductImage extends Model
 {
     protected $fillable = [
         'path'
+    ];
+
+    protected $dispatchesEvents = [
+        'deleting' => ProductImageDeleting::class,
     ];
 
     public function product()

--- a/database/migrations/2025_01_16_070723_create_product_images_table.php
+++ b/database/migrations/2025_01_16_070723_create_product_images_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('product_images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->text('path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('product_images');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::group(['prefix' => 'dashboard', 'middleware' => ['auth:api', 'admin-only'
 
             Route::group(['prefix' => 'images', 'controller' => AdminProductImageController::class], function () {
                 Route::post('', 'store');
+                Route::delete('{productImage}', 'destroy');
             });
         });
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\Admin\ProductController as AdminProductController;
+use App\Http\Controllers\Admin\ProductImageController as AdminProductImageController;
 use App\Http\Controllers\Admin\CategoryController as AdminCategoryController;
 
 Route::get('/user', function (Request $request) {
@@ -34,6 +35,10 @@ Route::group(['prefix' => 'dashboard', 'middleware' => ['auth:api', 'admin-only'
             Route::group(['prefix' => 'category'], function () {
                 Route::put('attach', 'attachCategories');
                 Route::put('detach', 'detachCategories');
+            });
+
+            Route::group(['prefix' => 'images', 'controller' => AdminProductImageController::class], function () {
+                Route::post('', 'store');
             });
         });
     });


### PR DESCRIPTION
Added product image creation and deletion endpoints. Product creation also supports image upload by passing in an array of images. An event and listener are created to handle image deletion on row deletion.

### Endpoints
| Path | Method | Description |
| - | - | - |
| `/dashboard/products/:productId/images` | `POST` | Upload a new image |
| `/dashboard/products/:productId/images/:imageId` | `DELETE` | Delete an image |
